### PR TITLE
Fixed new Int32Array(msg) failure

### DIFF
--- a/xwalk/common/common_api.js
+++ b/xwalk/common/common_api.js
@@ -31,7 +31,7 @@ internal.setupInternalExtension = function(extension_obj) {
 
   extension_object.setMessageListener(function(msg) {
     if (msg instanceof ArrayBuffer) {
-      var int32_array = new Int32Array(msg);
+      var int32_array = new Int32Array(msg, 0 , 4);
       var id = int32_array[0];
       var listener = callback_listeners[id];
 


### PR DESCRIPTION
When msg is not 4-divided, the new Int32Array(msg) will fail. So here,
add the byteOffset and byteLength.
