### PR TITLE
Add common_api_android.js adapter.

### DIFF
--- a/tools/concatenate-files.py
+++ b/tools/concatenate-files.py
@@ -1,0 +1,75 @@
+#!/usr/bin/env python
+#
+# Copyright 2014 the V8 project authors. All rights reserved.
+# Redistribution and use in source and binary forms, with or without
+# modification, are permitted provided that the following conditions are
+# met:
+#
+#     * Redistributions of source code must retain the above copyright
+#       notice, this list of conditions and the following disclaimer.
+#     * Redistributions in binary form must reproduce the above
+#       copyright notice, this list of conditions and the following
+#       disclaimer in the documentation and/or other materials provided
+#       with the distribution.
+#     * Neither the name of Google Inc. nor the names of its
+#       contributors may be used to endorse or promote products derived
+#       from this software without specific prior written permission.
+#
+# THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+# "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+# LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR
+# A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT
+# OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
+# SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT
+# LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE,
+# DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY
+# THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+# (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+# OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+
+# This utility concatenates several files into one. On Unix-like systems
+# it is equivalent to:
+#   cat file1 file2 file3 ...files... > target
+#
+# The reason for writing a seperate utility is that 'cat' is not available
+# on all supported build platforms, but Python is, and hence this provides
+# us with an easy and uniform way of doing this on all platforms.
+
+import optparse
+
+
+def Concatenate(filenames):
+  """Concatenate files.
+
+  Args:
+    files: Array of file names.
+           The last name is the target; all earlier ones are sources.
+
+  Returns:
+    True, if the operation was successful.
+  """
+  if len(filenames) < 2:
+    print "An error occured generating %s:\nNothing to do." % filenames[-1]
+    return False
+
+  try:
+    with open(filenames[-1], "wb") as target:
+      for filename in filenames[:-1]:
+        with open(filename, "rb") as current:
+          target.write(current.read())
+    return True
+  except IOError as e:
+    print "An error occured when writing %s:\n%s" % (filenames[-1], e)
+    return False
+
+
+def main():
+  parser = optparse.OptionParser()
+  parser.set_usage("""Concatenate several files into one.
+      Equivalent to: cat file1 ... > target.""")
+  (options, args) = parser.parse_args()
+  exit(0 if Concatenate(args) else 1)
+
+
+if __name__ == "__main__":
+  main()

--- a/xwalk/common/common_api_android.js
+++ b/xwalk/common/common_api_android.js
@@ -1,0 +1,177 @@
+// Copyright (c) 2015 Intel Corporation. All rights reserved.
+// Use of this source code is governed by a BSD-style license that can be
+// found in the LICENSE file.
+
+// internal won't be used anymore.
+var internal = {};
+internal.setupInternalExtension = function(extension_obj) {};
+internal.postMessage = function(function_name, args, callback) {};
+internal.removeCallback = function(id) {};
+
+var Common = function() {
+  var v8tools = requireNative('v8tools');
+  var jsStubModule = requireNative('jsStub');
+  jsStubModule.init(extension, v8tools);
+  var jsStub = jsStubModule.jsStub;
+  var rootHelper = jsStub.create(exports);
+
+  function getUniqueId() {
+    return 0;
+  }
+
+  var BindingObjectPrototype = function() {
+    // Won't be used anymore.
+    function postMessage(name, args, callback) {
+    };
+
+    function isEnumerable(method_name) {
+      return name.indexOf('_') != 0;
+    };
+
+    function addMethod(name, has_callback) {
+      Object.defineProperty(this, name, {
+        value: function() {
+          var args = Array.prototype.slice.call(arguments);
+          jsStub.getHelper(this, rootHelper).invokeNative(name, args, false);
+        },
+        enumerable: isEnumerable(name),
+      });
+    };
+
+    function invokeMethodWithPromise(self, name, args, wrapReturns) {
+      return new Promise(function(resolve, reject) {
+        var resolveWrapper = function(data) {
+          if (wrapReturns) {
+            resolve(wrapReturns(data));
+          } else {
+            resolve(data);
+          }
+        };
+        args.unshift({'resolve': resolveWrapper, 'reject': reject});
+        jsStub.getHelper(self, rootHelper).invokeNative(name, args, false);
+      });
+    };
+
+    function addMethodWithPromise(name, wrapArgs, wrapReturns) {
+      Object.defineProperty(this, name, {
+        value: function() {
+          var args = Array.prototype.slice.call(arguments);
+          if (wrapArgs)
+            args = wrapArgs(args);
+
+          return invokeMethodWithPromise(this, name, args, wrapReturns);
+        },
+        enumerable: isEnumerable(name),
+      });
+    };
+
+    function addMethodWithPromise2(name, wrapArgs, wrapReturns) {
+      Object.defineProperty(this, name, {
+        value: function() {
+          var self = this;
+          var args = Array.prototype.slice.call(arguments);
+          if (wrapArgs) {
+            return wrapArgs(args).then(function(resultData) {
+              return invokeMethodWithPromise(self, name, resultData, wrapReturns);
+            });
+          }
+
+          return invokeMethodWithPromise(self, name, args, wrapReturns);
+        },
+        enumerable: isEnumerable(name),
+      });
+    };
+
+    function registerLifecycleTracker() {
+      jsStub.getHelper(this, rootHelper).registerLifecycleTracker();
+    }
+
+    Object.defineProperties(this, {
+      '_postMessage' : {
+        value: postMessage,
+      },
+      '_addMethod' : {
+        value: addMethod,
+      },
+      '_addMethodWithPromise' : {
+        value: addMethodWithPromise,
+      },
+      '_addMethodWithPromise2': {
+        value: addMethodWithPromise2,
+      },
+      '_registerLifecycleTracker' : {
+        value: registerLifecycleTracker,
+      },
+    });
+  };
+
+  var BindingObject = function(objectId, cName) {
+    if (rootHelper.getBindingObject(Number(objectId)) != undefined) {
+      return;
+    }
+
+    // Request Java side to create BindingObject.
+    objectId = Number(rootHelper.invokeNative('+' + cName, true));
+    if (!objectId) throw 'Error to create instance for constructor: ' + cName;
+    var objectHelper = jsStub.getHelper(this, rootHelper);
+    objectHelper.objectId = objectId;
+    objectHelper.constructorJsName = cName;
+    objectHelper.registerLifecycleTracker();
+
+    rootHelper.addBindingObject(objectId, this);
+
+    Object.defineProperties(this, {
+      '_id': {
+        value: objectId,
+      },
+    });
+  };
+
+  // addEventListener, removeEventListener, dispatchEvent
+  // are already exposed by jsStub.makeEventTarget(),
+  // so no need to define them again in prototype,
+  // just adapt addEvent to helper's addEvent.
+  var EventTargetPrototype = function() {
+    function addEvent(type, event) {
+      jsStub.getHelper(this, rootHelper).addEvent(type);
+    };
+
+    Object.defineProperties(this, {
+      '_addEvent' : {
+        value: addEvent,
+      },
+    });
+  };
+
+  var EventTarget = function(object_id) {
+    jsStub.makeEventTarget(this);
+  };
+
+  EventTargetPrototype.prototype = new BindingObjectPrototype();
+
+  Object.defineProperties(this, {
+    'getUniqueId': {
+      value: getUniqueId,
+      enumerable: true
+    },
+    'BindingObjectPrototype': {
+      value: BindingObjectPrototype,
+      enumerable: true
+    },
+    'BindingObject': {
+      value: BindingObject,
+      enumerable: true
+    },
+    'EventTargetPrototype': {
+      value: EventTargetPrototype,
+      enumerable: true
+    },
+    'EventTarget': {
+      value: EventTarget,
+      enumerable: true
+    }
+  });
+};
+
+var common = new Common();
+


### PR DESCRIPTION
common_api_android.js provides the same capability with common_api.js,
by employing Crosswalk android jsStub module, which provides support
for BindingObject and EventTarget.
This will enable android extension developer reuse their Windows version
API js files based on common_api.js. Android API js file would be
automatically created as 'common_api_android.js + Windows API js file'.
