### PR TITLE
Avoid error on serializing ArrayBuffer into json.

### DIFF
--- a/xwalk/common/xwalk_extension_function_handler.cc
+++ b/xwalk/common/xwalk_extension_function_handler.cc
@@ -202,7 +202,7 @@ void XWalkExtensionFunctionHandler::PostMessageToInstance(
     } else {
       std::string value;
       JSONStringValueSerializer serializer(&value);
-      serializer.Serialize(*msg);
+      serializer.SerializeAndOmitBinaryValues(*msg);
       instance_->PostMessage(value.c_str());
     }
   }


### PR DESCRIPTION
Some binary data members are defined in .idl as ArrayBuffer,
when they are posted from native to js, json serializing always fail.
Use JSONStringValueSerializer::SerializeAndOmitBinaryValues()
instead of JSONStringValueSerializer::Serialize() to avoid.
