### PR TITLE
Remove android_tools from DEPS

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -67,5 +67,4 @@ _out
 /tools/json_schema_compiler/test/json_schema_compiler_tests.xml
 /out*
 /third_party/colorama/src
-/third_party/android_tools
 /third_party/jsr-305/src

--- a/DEPS
+++ b/DEPS
@@ -27,9 +27,6 @@ deps = {
 deps_os = {
   'android':
   {
-    'third_party/android_tools':
-    Var('chromium_git') + '/android_tools.git' + '@' + '1c8df186756bedd686bd293b65065ee6ae321d21',
-
     'third_party/jsr-305/src':
     Var('chromium_git') + '/external/jsr-305.git' + '@' + '642c508235471f7220af6d5df2d3210e3bfc0919',
   }

--- a/third_party/android_tools/LICENSE
+++ b/third_party/android_tools/LICENSE
@@ -1,0 +1,218 @@
+Notice for all the files in this folder.
+------------------------------------------------------------
+
+
+   
+   Copyright (c) 2005-2008, The Android Open Source Project
+
+   Licensed under the Apache License, Version 2.0 (the "License"); you may not
+   use this file except in compliance with the License.
+ 
+   Unless required by applicable law or agreed to in writing, software
+   distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+   WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.  See the
+   License for the specific language governing permissions and limitations under
+   the License.
+
+                                 Apache License
+                           Version 2.0, January 2004
+                        http://www.apache.org/licenses/
+
+   TERMS AND CONDITIONS FOR USE, REPRODUCTION, AND DISTRIBUTION
+
+   1. Definitions.
+
+      "License" shall mean the terms and conditions for use, reproduction,
+      and distribution as defined by Sections 1 through 9 of this document.
+
+      "Licensor" shall mean the copyright owner or entity authorized by
+      the copyright owner that is granting the License.
+
+      "Legal Entity" shall mean the union of the acting entity and all
+      other entities that control, are controlled by, or are under common
+      control with that entity. For the purposes of this definition,
+      "control" means (i) the power, direct or indirect, to cause the
+      direction or management of such entity, whether by contract or
+      otherwise, or (ii) ownership of fifty percent (50%) or more of the
+      outstanding shares, or (iii) beneficial ownership of such entity.
+
+      "You" (or "Your") shall mean an individual or Legal Entity
+      exercising permissions granted by this License.
+
+      "Source" form shall mean the preferred form for making modifications,
+      including but not limited to software source code, documentation
+      source, and configuration files.
+
+      "Object" form shall mean any form resulting from mechanical
+      transformation or translation of a Source form, including but
+      not limited to compiled object code, generated documentation,
+      and conversions to other media types.
+
+      "Work" shall mean the work of authorship, whether in Source or
+      Object form, made available under the License, as indicated by a
+      copyright notice that is included in or attached to the work
+      (an example is provided in the Appendix below).
+
+      "Derivative Works" shall mean any work, whether in Source or Object
+      form, that is based on (or derived from) the Work and for which the
+      editorial revisions, annotations, elaborations, or other modifications
+      represent, as a whole, an original work of authorship. For the purposes
+      of this License, Derivative Works shall not include works that remain
+      separable from, or merely link (or bind by name) to the interfaces of,
+      the Work and Derivative Works thereof.
+
+      "Contribution" shall mean any work of authorship, including
+      the original version of the Work and any modifications or additions
+      to that Work or Derivative Works thereof, that is intentionally
+      submitted to Licensor for inclusion in the Work by the copyright owner
+      or by an individual or Legal Entity authorized to submit on behalf of
+      the copyright owner. For the purposes of this definition, "submitted"
+      means any form of electronic, verbal, or written communication sent
+      to the Licensor or its representatives, including but not limited to
+      communication on electronic mailing lists, source code control systems,
+      and issue tracking systems that are managed by, or on behalf of, the
+      Licensor for the purpose of discussing and improving the Work, but
+      excluding communication that is conspicuously marked or otherwise
+      designated in writing by the copyright owner as "Not a Contribution."
+
+      "Contributor" shall mean Licensor and any individual or Legal Entity
+      on behalf of whom a Contribution has been received by Licensor and
+      subsequently incorporated within the Work.
+
+   2. Grant of Copyright License. Subject to the terms and conditions of
+      this License, each Contributor hereby grants to You a perpetual,
+      worldwide, non-exclusive, no-charge, royalty-free, irrevocable
+      copyright license to reproduce, prepare Derivative Works of,
+      publicly display, publicly perform, sublicense, and distribute the
+      Work and such Derivative Works in Source or Object form.
+
+   3. Grant of Patent License. Subject to the terms and conditions of
+      this License, each Contributor hereby grants to You a perpetual,
+      worldwide, non-exclusive, no-charge, royalty-free, irrevocable
+      (except as stated in this section) patent license to make, have made,
+      use, offer to sell, sell, import, and otherwise transfer the Work,
+      where such license applies only to those patent claims licensable
+      by such Contributor that are necessarily infringed by their
+      Contribution(s) alone or by combination of their Contribution(s)
+      with the Work to which such Contribution(s) was submitted. If You
+      institute patent litigation against any entity (including a
+      cross-claim or counterclaim in a lawsuit) alleging that the Work
+      or a Contribution incorporated within the Work constitutes direct
+      or contributory patent infringement, then any patent licenses
+      granted to You under this License for that Work shall terminate
+      as of the date such litigation is filed.
+
+   4. Redistribution. You may reproduce and distribute copies of the
+      Work or Derivative Works thereof in any medium, with or without
+      modifications, and in Source or Object form, provided that You
+      meet the following conditions:
+
+      (a) You must give any other recipients of the Work or
+          Derivative Works a copy of this License; and
+
+      (b) You must cause any modified files to carry prominent notices
+          stating that You changed the files; and
+
+      (c) You must retain, in the Source form of any Derivative Works
+          that You distribute, all copyright, patent, trademark, and
+          attribution notices from the Source form of the Work,
+          excluding those notices that do not pertain to any part of
+          the Derivative Works; and
+
+      (d) If the Work includes a "NOTICE" text file as part of its
+          distribution, then any Derivative Works that You distribute must
+          include a readable copy of the attribution notices contained
+          within such NOTICE file, excluding those notices that do not
+          pertain to any part of the Derivative Works, in at least one
+          of the following places: within a NOTICE text file distributed
+          as part of the Derivative Works; within the Source form or
+          documentation, if provided along with the Derivative Works; or,
+          within a display generated by the Derivative Works, if and
+          wherever such third-party notices normally appear. The contents
+          of the NOTICE file are for informational purposes only and
+          do not modify the License. You may add Your own attribution
+          notices within Derivative Works that You distribute, alongside
+          or as an addendum to the NOTICE text from the Work, provided
+          that such additional attribution notices cannot be construed
+          as modifying the License.
+
+      You may add Your own copyright statement to Your modifications and
+      may provide additional or different license terms and conditions
+      for use, reproduction, or distribution of Your modifications, or
+      for any such Derivative Works as a whole, provided Your use,
+      reproduction, and distribution of the Work otherwise complies with
+      the conditions stated in this License.
+
+   5. Submission of Contributions. Unless You explicitly state otherwise,
+      any Contribution intentionally submitted for inclusion in the Work
+      by You to the Licensor shall be under the terms and conditions of
+      this License, without any additional terms or conditions.
+      Notwithstanding the above, nothing herein shall supersede or modify
+      the terms of any separate license agreement you may have executed
+      with Licensor regarding such Contributions.
+
+   6. Trademarks. This License does not grant permission to use the trade
+      names, trademarks, service marks, or product names of the Licensor,
+      except as required for reasonable and customary use in describing the
+      origin of the Work and reproducing the content of the NOTICE file.
+
+   7. Disclaimer of Warranty. Unless required by applicable law or
+      agreed to in writing, Licensor provides the Work (and each
+      Contributor provides its Contributions) on an "AS IS" BASIS,
+      WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+      implied, including, without limitation, any warranties or conditions
+      of TITLE, NON-INFRINGEMENT, MERCHANTABILITY, or FITNESS FOR A
+      PARTICULAR PURPOSE. You are solely responsible for determining the
+      appropriateness of using or redistributing the Work and assume any
+      risks associated with Your exercise of permissions under this License.
+
+   8. Limitation of Liability. In no event and under no legal theory,
+      whether in tort (including negligence), contract, or otherwise,
+      unless required by applicable law (such as deliberate and grossly
+      negligent acts) or agreed to in writing, shall any Contributor be
+      liable to You for damages, including any direct, indirect, special,
+      incidental, or consequential damages of any character arising as a
+      result of this License or out of the use or inability to use the
+      Work (including but not limited to damages for loss of goodwill,
+      work stoppage, computer failure or malfunction, or any and all
+      other commercial damages or losses), even if such Contributor
+      has been advised of the possibility of such damages.
+
+   9. Accepting Warranty or Additional Liability. While redistributing
+      the Work or Derivative Works thereof, You may choose to offer,
+      and charge a fee for, acceptance of support, warranty, indemnity,
+      or other liability obligations and/or rights consistent with this
+      License. However, in accepting such obligations, You may act only
+      on Your own behalf and on Your sole responsibility, not on behalf
+      of any other Contributor, and only if You agree to indemnify,
+      defend, and hold each Contributor harmless for any liability
+      incurred by, or claims asserted against, such Contributor by reason
+      of your accepting any such warranty or additional liability.
+
+   END OF TERMS AND CONDITIONS
+
+   APPENDIX: How to apply the Apache License to your work.
+
+      To apply the Apache License to your work, attach the following
+      boilerplate notice, with the fields enclosed by brackets "[]"
+      replaced with your own identifying information. (Don't include
+      the brackets!)  The text should be enclosed in the appropriate
+      comment syntax for the file format. We also recommend that a
+      file or class name and description of purpose be included on the
+      same "printed page" as the copyright notice for easier
+      identification within third-party archives.
+
+   Copyright 2011 Google Inc. All Rights Reserved.
+
+   Licensed under the Apache License, Version 2.0 (the "License");
+   you may not use this file except in compliance with the License.
+   You may obtain a copy of the License at
+
+       http://www.apache.org/licenses/LICENSE-2.0
+
+   Unless required by applicable law or agreed to in writing, software
+   distributed under the License is distributed on an "AS IS" BASIS,
+   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+   See the License for the specific language governing permissions and
+   limitations under the License.
+

--- a/third_party/android_tools/README.chromium
+++ b/third_party/android_tools/README.chromium
@@ -1,0 +1,51 @@
+Name: Android Tools (SDK/NDK)
+URL: http://developer.android.com/sdk/index.html
+Versions:
+  NDK r10c
+  Android SDK Platform API 22
+  Android SDK Tools 24.1.2
+  Android SDK Platform-tools 22
+  Android SDK Build-tools 22
+  Android SDK Sources 22
+  Android Support Library 22.0.0
+  Google Cloud Messaging 3
+Security Critical: no
+License: Apache Version 2.0
+
+Description:
+The Android SDK/NDK provide API libraries and developer tools necessary to
+build, test and debug for Android.
+
+Local Modifications:
+
+-In ndk/
+- Removed old android platforms in platforms/
+  (anything under android-14)
+- Removed GCC 4.6 toolchains in toolchains/
+  as they are deprecated and no longer used in Chromium.
+- Also deleted sources/cxx-stl/gnu-libstdc++/4.6/ for the same reason.
+- Edited stlport to force GCC to do "proper" inlining decisions
+  (see crbug.com/377433)
+    sources/cxx-stl/stlport/stlport/stl/_construct.h
+    sources/cxx-stl/stlport/stlport/stl/_vector.c
+- Cherry-picked https://android-review.googlesource.com/#/c/123717/
+- Cherry-picked
+    http://llvm.org/viewvc/llvm-project?view=revision&revision=227226
+-Cherry-picked more recent version of the aarch64 toolchain containing
+    https://android-review.googlesource.com/#/c/113144/
+    https://android-review.googlesource.com/#/c/118930/
+    https://android-review.googlesource.com/#/c/144632/
+
+-In sdk/
+- Included the Android support library and required extras packages
+- Removed unused resources from the support library (see crbug.com/372481)
+- Updated trace-viewer script to r220 under sdk/tools/systrace.
+  Steps to update to the latest version of trace-viewer:
+    git clone https://android.googlesource.com/platform/external/chromium-trace
+    cd chromium-trace
+    ./update.py
+    cp script.js style.css $ANDROID_SDK_ROOT/tools/systrace
+ - Modified sdk/extras/android/support/v7/appcompat/res/layout/abc_activity_chooser_view.xml
+   by replacing accidental use of layout_marginEnd with layout_marginBottom.
+
+No other modifications has been made to the public Android SDK/NDK.

--- a/third_party/android_tools/android_tools.gyp
+++ b/third_party/android_tools/android_tools.gyp
@@ -1,0 +1,173 @@
+# Copyright (c) 2010 The Chromium Authors. All rights reserved.
+# Use of this source code is governed by a BSD-style license that can be
+# found in the LICENSE file.
+{
+  'targets': [
+    {
+      'target_name': 'android_java',
+      'type' : 'none',
+      'variables': {
+        'jar_path': '<(android_sdk)/android.jar',
+        'exclude_from_apk': 1,
+      },
+      'includes': ['../../build/java_prebuilt.gypi'],
+    },
+    {
+      'target_name': 'android_gcm',
+      'type' : 'none',
+      'variables': {
+        'jar_path': '<(android_sdk_root)/extras/google/gcm/gcm-client/dist/gcm.jar',
+      },
+      'includes': ['../../build/java_prebuilt.gypi'],
+    },
+    {
+      'target_name': 'uiautomator_jar',
+      'type': 'none',
+      'variables': {
+        'jar_path': '<(android_sdk)/uiautomator.jar',
+        # uiautomator is provided by the framework.
+        'neverlink': 1,
+      },
+      'includes': ['../../build/java_prebuilt.gypi'],
+    },
+    {
+      # This jar contains the Android support v13 library from the revision 18
+      # of the Android Support library.
+      'target_name': 'android_support_v13_javalib',
+      'type' : 'none',
+      'variables': {
+        'jar_path': '<(android_sdk_root)/extras/android/support/v13/android-support-v13.jar',
+      },
+      'includes': ['../../build/java_prebuilt.gypi'],
+    },
+    {
+      # This jar contains the Android support v7 appcompat library from the
+      # revision 18 of the Android Support library. This library doesn't
+      # contain the resources needed for the library to work.
+      # TODO(avayvod): Add the resources directly once crbug.com/274697 is
+      # fixed.
+      'target_name': 'android_support_v7_appcompat_javalib_no_res',
+      'type' : 'none',
+      'variables': {
+        'jar_path': '<(android_sdk_root)/extras/android/support/v7/appcompat/libs/android-support-v7-appcompat.jar',
+      },
+      'includes': ['../../build/java_prebuilt.gypi'],
+    },
+    {
+      # This jar contains the Android support v7 mediarouter library from the
+      # revision 18 of the Android Support library. This library doesn't
+      # contain the resources needed for the library to work.
+      # TODO(avayvod): Add the resources directly once crbug.com/274697 is
+      # fixed.
+      'target_name': 'android_support_v7_mediarouter_javalib_no_res',
+      'type' : 'none',
+      'variables': {
+        'jar_path': '<(android_sdk_root)/extras/android/support/v7/mediarouter/libs/android-support-v7-mediarouter.jar',
+      },
+      'includes': ['../../build/java_prebuilt.gypi'],
+    },
+    {
+      # This jar contains the Google Play services library without the
+      # resources needed for the library to work.
+      'target_name': 'google_play_services_default_javalib_no_res',
+      'type': 'none',
+      'variables': {
+        'jar_path': '<(android_sdk_root)/extras/google/google_play_services/libproject/google-play-services_lib/libs/google-play-services.jar',
+        # TODO(aberent): Remove this after some appropriate period of time.
+        '__check_that_google_play_services_is_installed':
+          '<!(test -e <(jar_path) -o -z "                                                            \
+                                                                                                     \
+              google-play-services.jar not found. Please re-run build/install-build-deps-android.sh. \
+              See https://groups.google.com/a/chromium.org/forum/#!topic/chromium-dev/bN0CgZTm3t8    \
+                                                                                                     \
+          ")',
+      },
+      'dependencies': [
+        'android_support_v13_javalib'
+      ],
+      'includes': ['../../build/java_prebuilt.gypi'],
+    },
+    {
+      # This target contains the Android support v7 appcompat library with the
+      # resources needed.
+      'target_name': 'android_support_v7_appcompat_javalib',
+      'type': 'none',
+      'variables': {
+        'java_in_dir': '<(android_sdk_root)/extras/android/support/v7/appcompat',
+        'R_package': ['android.support.v7.appcompat'],
+        'R_package_relpath': ['android/support/v7/appcompat'],
+        'has_java_resources': 1,
+        'res_v14_verify_only': 1,
+      },
+      'dependencies': [
+        'android_support_v7_appcompat_javalib_no_res',
+      ],
+      'includes': [ '../../build/java.gypi' ]
+    },
+    {
+      # This target contains the Android support v7 mediarouter library with the
+      # resources needed.
+      'target_name': 'android_support_v7_mediarouter_javalib',
+      'type': 'none',
+      'variables': {
+        'java_in_dir': '<(android_sdk_root)/extras/android/support/v7/mediarouter',
+        'R_package': ['android.support.v7.mediarouter'],
+        'R_package_relpath': ['android/support/v7/mediarouter'],
+        'has_java_resources': 1,
+        'res_v14_verify_only': 1,
+      },
+      'dependencies': [
+        'android_support_v7_mediarouter_javalib_no_res',
+        'android_support_v7_appcompat_javalib',
+      ],
+      'includes': [ '../../build/java.gypi' ]
+    },
+    {
+      # This jar contains the Android support v7 recyclerview library from the
+      # revision 21 of the Android Support library. This library doesn't
+      # contain the resources needed for the library to work.
+      'target_name': 'android_support_v7_recyclerview_javalib',
+      'type' : 'none',
+      'variables': {
+        'jar_path': '<(android_sdk_root)/extras/android/support/v7/recyclerview/libs/android-support-v7-recyclerview.jar',
+      },
+      'dependencies': [
+      ],
+      'includes': ['../../build/java_prebuilt.gypi'],
+    },
+    {
+      # This target contains the Google Play services library with the
+      # resources needed. It will fail to build unless you have a local
+      # version of the Google Play services library (as installed by
+      # install_build_deps_android.sh).
+      # This target should never be used directly, since a build may need
+      # to use a conflicting version of Google Play Services. Targets depending
+      # on Google Play Services should depend on google_play_services_javalib to allow
+      # this.
+      'target_name': 'google_play_services_default_javalib',
+      'type': 'none',
+      'variables': {
+        'java_in_dir': '<(android_sdk_root)/extras/google/google_play_services/libproject/google-play-services_lib',
+        'R_package': ['com.google.android.gms'],
+        'R_package_relpath': ['com/google/android/gms'],
+        'has_java_resources': 1,
+        'res_v14_verify_only': 1,
+      },
+      'dependencies': [
+        'google_play_services_default_javalib_no_res',
+      ],
+      'includes': ['../../build/java.gypi'],
+    },
+    {
+      # This target wraps the Google Play Services library, allowing the use of alternative versions of it as
+      # needed. An alternative version can be selected by setting google_play_services_library_target to
+      # a target that provides the alternative version.
+      'target_name': 'google_play_services_javalib',
+      'type': 'none',
+      'dependencies': [
+        '<(google_play_services_library_target)',
+      ],
+    },
+  ],
+  'variables': {'google_play_services_library_target%': 'google_play_services_default_javalib'},
+}

--- a/third_party/android_tools/prepare_android_tools.sh
+++ b/third_party/android_tools/prepare_android_tools.sh
@@ -1,0 +1,54 @@
+#!/bin/bash
+# Copyright (c) 2015 Intel Corporation. All rights reserved.
+# Use of this source code is governed by a BSD-style license that can be
+# found in the LICENSE file.
+
+ANDROID_NDK_VERSION=android-ndk-r10e
+ANDROID_NDK_FILE=${ANDROID_NDK_VERSION}-linux-x86_64.bin
+ANDROID_NDK_CHECKSUM=e28bdb459362685d5a59b8ba2ef9fff8
+ANDROID_SDK_VERSION=22
+ANDROID_SDK_BUILD_TOOLS_VERSION=22.0.0
+
+prepare_ndk() {
+  curl -LO http://dl.google.com/android/ndk/${ANDROID_NDK_FILE}
+  chmod u+x ${ANDROID_NDK_FILE}
+  ./${ANDROID_NDK_FILE} > /dev/null
+  rm ${ANDROID_NDK_FILE}
+  mv ${ANDROID_NDK_VERSION} ndk
+}
+
+checksum_ndk() {
+  echo `find ndk -type f -exec md5sum {} + | awk '{print $1}' | sort | md5sum | awk '{print $1}'`
+}
+
+cd "$( dirname "${BASH_SOURCE[0]}" )"
+
+echo "preparing ndk..."
+if [ ! -d "ndk" ]; then
+  prepare_ndk
+elif [ $(checksum_ndk) != $ANDROID_NDK_CHECKSUM ]; then
+  rm -rf ndk
+  prepare_ndk
+fi
+
+echo "preparing sdk..."
+if [ ! ${ANDROID_HOME} ]; then
+  echo "Please set ANDROID_HOME to Android SDK root"
+  return 1;
+fi
+
+if [ ! -d ${ANDROID_HOME}/platforms/android-${ANDROID_SDK_VERSION} ]; then
+  echo y | android update sdk --all --no-ui --filter android-${ANDROID_SDK_VERSION}
+fi
+
+if [ ! -d ${ANDROID_HOME}/build-tools/${ANDROID_SDK_BUILD_TOOLS_VERSION} ]; then
+  echo y | android update sdk --all --no-ui --filter build-tools-${ANDROID_SDK_BUILD_TOOLS_VERSION}
+fi
+
+if [ ! -d "sdk" ]; then
+  ln -s ${ANDROID_HOME} sdk
+fi
+
+cd -
+
+echo "done"


### PR DESCRIPTION
git clone android_tools takes long time.
It causes build failure on travis CI.

This commit implments:
1. remote android_tools repo from DEPS
2. import android_tools.gyp, LICENSE and README.chromium
   from android_tools repo
3. add prepare_android_tools.sh to create ndk and sdk
3.1 download ndk if needed
3.2 use system installed sdk

Development change:
1. Install Android SDK and export ANDROID_HOME
2. add prepare_android_tools.sh into .gclient hooks

hooks = [
  {
    'name': 'prepare_android_tools',
    'pattern': '.',
    'action': ['bash', 'src/third_party/android_tools/prepare_android_tools.sh'],
  },
]
