### PR TITLE
Removed 'gyp_all' hooks from DEPS.

### DIFF
--- a/DEPS
+++ b/DEPS
@@ -69,10 +69,4 @@ hooks = [
     'pattern': '.',
     'action': ['python', 'src/tools/clang/scripts/update.py', '--if-needed'],
   },
-  # TODO: Switch to GN later.
-  {
-    "name": "gyp_all",
-    "pattern": ".",
-    "action": ["python", "src/gyp_all"],
-  }
 ]


### PR DESCRIPTION
As the android tool preparation hooks has been moved into the
android repo and will not be needed to add in the .gclient explicitly,
we'd remove the 'gyp_all' hook here and run the gyp_all command manually
after the hooks complete, as discussed in the PR thread:

https://github.com/otcshare/realsense-extensions-crosswalk-android/pull/4

Travis and Appveyor have already configured with the explicit calling of
'python gyp_all', so this change won't affect the buildbots' behaviors.
