### PR TITLE
[IDL Generator] Fix the enum namespace issue of initializer generation

### DIFF
--- a/tools/json_schema_compiler/cc_generator.py
+++ b/tools/json_schema_compiler/cc_generator.py
@@ -148,9 +148,12 @@ class _Generator(object):
 
       real_t = self._type_helper.FollowRef(t)
       if real_t.property_type == PropertyType.ENUM:
-        items.append('%s(%s)' % (
-            prop.unix_name,
-            self._type_helper.GetEnumNoneValue(t)))
+        namespace_prefix = ('%s::' % real_t.namespace.unix_name
+                            if real_t.namespace != self._namespace
+                            else '')
+        items.append('%s(%s%s)' % (prop.unix_name,
+                                   namespace_prefix,
+                                   self._type_helper.GetEnumNoneValue(t)))
       elif prop.optional:
         continue
       elif t.property_type == PropertyType.INTEGER:


### PR DESCRIPTION
This is partially backport of https://chromium.googlesource.com/chromium/src/+/00f1fc22bfcc653b47d62778170af3eee9855720

Please drop this when rebasing to Chromium.