### PR TITLE
Fixed linting ignore feature not working on Windows.

### DIFF
--- a/tools/lint.py
+++ b/tools/lint.py
@@ -260,7 +260,9 @@ def do_js_lint(changeset):
 def get_all_files(dir):
   files = []
   for name in os.listdir(dir):
-    path = os.path.join(dir, name)
+    # Posix path seperator '/' is used in .lintignore and git diff --name-only
+    # So os.path.join is not suitable here
+    path = dir + '/' + name
     if os.path.isfile(path):
       files.append(path)
     else:


### PR DESCRIPTION
When a directory specified in .lintignore, all files will be added
recursively, as we used os.path.join, the use separator '\' will be used on
Windows. At the same time, 'git diff --name-only' report files with posix
separator '/'. This will cause string comparison always fail.

The solution is simply join with posix seperator '/', not use os.path.join()