### PR TITLE
[IDL Generator] introduce dash_delimited_enum_string directive

### DIFF
--- a/tools/json_schema_compiler/cc_generator.py
+++ b/tools/json_schema_compiler/cc_generator.py
@@ -936,6 +936,8 @@ class _Generator(object):
       name = enum_value.name
       if 'camel_case_enum_to_string' in self._namespace.compiler_options:
         name = enum_value.CamelName()
+      if 'dash_delimited_enum_string' in self._namespace.compiler_options:
+        name = enum_value.DashDelimitedName()
       (c.Append('case %s: ' % self._type_helper.GetEnumValue(type_, enum_value))
         .Append('  return "%s";' % name))
     (c.Append('case %s:' % self._type_helper.GetEnumNoneValue(type_))
@@ -965,7 +967,10 @@ class _Generator(object):
       # This is broken up into all ifs with no else ifs because we get
       # "fatal error C1061: compiler limit : blocks nested too deeply"
       # on Windows.
-      (c.Append('if (enum_string == "%s")' % enum_value.name)
+      name = enum_value.name
+      if 'dash_delimited_enum_string' in self._namespace.compiler_options:
+        name = enum_value.DashDelimitedName()
+      (c.Append('if (enum_string == "%s")' % name)
         .Append('  return %s;' %
             self._type_helper.GetEnumValue(type_, enum_value)))
     (c.Append('return %s;' % self._type_helper.GetEnumNoneValue(type_))

--- a/tools/json_schema_compiler/idl_schema.py
+++ b/tools/json_schema_compiler/idl_schema.py
@@ -497,6 +497,8 @@ class IDLSchema(object):
           compiler_options['implemented_in'] = node.value
         elif node.name == 'camel_case_enum_to_string':
           compiler_options['camel_case_enum_to_string'] = node.value
+        elif node.name == 'dash_delimited_enum_string':
+          compiler_options['dash_delimited_enum_string'] = node.value
         elif node.name == 'deprecated':
           deprecated = str(node.value)
         elif node.name == 'documentation_title':

--- a/tools/json_schema_compiler/model.py
+++ b/tools/json_schema_compiler/model.py
@@ -423,6 +423,9 @@ class EnumValue(object):
   def CamelName(self):
     return CamelName(self.name)
 
+  def DashDelimitedName(self):
+    return DashDelimitedName(self.name)
+
 class _Enum(object):
   """Superclass for enum types with a "name" field, setting up repr/eq/ne.
   Enums need to do this so that equality/non-equality work over pickling.
@@ -510,6 +513,19 @@ def CamelName(snake):
     else:
       camel.append(piece.capitalize())
   return ''.join(camel)
+
+@memoize
+def DashDelimitedName(snake):
+  ''' Converts a snake_cased_string to a dash-delimited-string. '''
+  pieces = snake.split('_')
+  dash_delimited_name = []
+  for i, piece in enumerate(pieces):
+    if i == 0:
+      dash_delimited_name.append(piece)
+    else:
+      dash_delimited_name.append('-')
+      dash_delimited_name.append(piece);
+  return ''.join(dash_delimited_name)
 
 
 def _StripNamespace(name, namespace):


### PR DESCRIPTION
Usage:

Declaration in .idl file, e.g:

[camel_case_enum_to_string=true] namespace face {
enum TrackingModeType {
  color,
  color_depth
};
}

The generated enum is:

enum TrackingModeType {
  "color",
  "color-depth"
};

BUG=XWALK-6712
